### PR TITLE
Moved custom-style out of dom-module

### DIFF
--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -53,15 +53,18 @@ in another form (e.g. a text block following the spinner).
 @homepage http://polymer.github.io/paper-spinner
 -->
 
-<dom-module id="paper-spinner">
-  <style is="custom-style">
+<style is="custom-style">
+  /* Default colors */
   * {
     --paper-spinner-layer-1-color: #4285f4;
     --paper-spinner-layer-2-color: #db4437;
     --paper-spinner-layer-3-color: #f4b400;
     --paper-spinner-layer-4-color: #0f9d58;
   }
-  </style>
+</style>
+
+
+<dom-module id="paper-spinner">
 
   <link rel="import" type="css" href="paper-spinner.css">
 


### PR DESCRIPTION
Fixes the issue of paper-spinner not applying default colors.