### PR TITLE
Fixed default `--paper-spinner-layer-4-color`

### DIFF
--- a/paper-spinner.css
+++ b/paper-spinner.css
@@ -77,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .layer-4 {
-  border-color: var(--paper-spinner-layer-4-color, --google-blue-500);
+  border-color: var(--paper-spinner-layer-4-color, --google-green-500);
 }
 
 /**


### PR DESCRIPTION
The default for `--paper-spinner-layer-4-color` was `--google-blue-500` when the docs say it should be `--google-green-500`.