### PR TITLE
Added a single color <paper-spinner-lite>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,5 +30,8 @@
     "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "main": "paper-spinner.html"
+  "main": [
+    "paper-spinner.html",
+    "paper-spinner-lite.html"
+  ]
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,45 +16,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../../paper-styles/demo-pages.html">
     <link rel="import" href="../paper-spinner.html">
+    <link rel="import" href="../paper-spinner-lite.html">
 
     <style is="custom-style">
       .horizontal-section {
         width: 100px;
       }
 
-      paper-spinner, button {
+      paper-spinner, paper-spinner-lite, button {
         display: block;
         margin-bottom: 24px;
         margin-left: auto;
         margin-right: auto;
       }
 
-      paper-spinner.blue {
-        --paper-spinner-layer-1-color: var(--paper-light-blue-500);
-        --paper-spinner-layer-2-color: var(--paper-light-blue-500);
-        --paper-spinner-layer-3-color: var(--paper-light-blue-500);
-        --paper-spinner-layer-4-color: var(--paper-light-blue-500);
+      paper-spinner.multi {
+        --paper-spinner-layer-1-color: var(--paper-purple-500);
+        --paper-spinner-layer-2-color: var(--paper-cyan-500);
+        --paper-spinner-layer-3-color: var(--paper-blue-grey-500);
+        --paper-spinner-layer-4-color: var(--paper-amber-500);
       }
 
-      paper-spinner.red {
-        --paper-spinner-layer-1-color: var(--paper-red-500);
-        --paper-spinner-layer-2-color: var(--paper-red-500);
-        --paper-spinner-layer-3-color: var(--paper-red-500);
-        --paper-spinner-layer-4-color: var(--paper-red-500);
+      paper-spinner-lite.red {
+        --paper-spinner-color: var(--google-red-500);
       }
 
-      paper-spinner.orange {
-        --paper-spinner-layer-1-color: var(--paper-orange-500);
-        --paper-spinner-layer-2-color: var(--paper-orange-500);
-        --paper-spinner-layer-3-color: var(--paper-orange-500);
-        --paper-spinner-layer-4-color: var(--paper-orange-500);
+      paper-spinner-lite.orange {
+        --paper-spinner-color: var(--google-yellow-500);
       }
 
-      paper-spinner.green {
-        --paper-spinner-layer-1-color: var(--paper-green-500);
-        --paper-spinner-layer-2-color: var(--paper-green-500);
-        --paper-spinner-layer-3-color: var(--paper-green-500);
-        --paper-spinner-layer-4-color: var(--paper-green-500);
+      paper-spinner-lite.green {
+        --paper-spinner-color: var(--google-green-500);
       }
     </style>
   </head>
@@ -62,23 +54,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body unresolved>
     <div class="horizontal-section-container">
       <div>
-        <h4>Default</h4>
+        <h4>&lt;paper-spinner&gt;</h4>
         <div class="horizontal-section">
           <paper-spinner></paper-spinner>
           <paper-spinner active></paper-spinner>
-          <paper-spinner></paper-spinner>
-          <paper-spinner active></paper-spinner>
+          <paper-spinner class="multi"></paper-spinner>
+          <paper-spinner class="multi" active></paper-spinner>
           <button onclick="toggle(event)">Toggle</button>
         </div>
       </div>
 
       <div>
-        <h4>Color</h4>
+        <h4>&lt;paper-spinner-lite&gt;</h4>
         <div class="horizontal-section">
-          <paper-spinner class="blue" active></paper-spinner>
-          <paper-spinner class="red" active></paper-spinner>
-          <paper-spinner class="orange" active></paper-spinner>
-          <paper-spinner class="green" active></paper-spinner>
+          <paper-spinner-lite active></paper-spinner-lite>
+          <paper-spinner-lite class="red" active></paper-spinner-lite>
+          <paper-spinner-lite class="orange" active></paper-spinner-lite>
+          <paper-spinner-lite class="green" active></paper-spinner-lite>
           <button onclick="toggle(event)">Toggle</button>
         </div>
       </div>
@@ -86,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       function toggle(event) {
-        var spinners = event.target.parentElement.querySelectorAll('paper-spinner');
+        var spinners = event.target.parentElement.querySelectorAll('paper-spinner, paper-spinner-lite');
         Array.prototype.forEach.call(spinners, function(spinner) {
           spinner.active = !spinner.active;
         });

--- a/paper-spinner-behavior.html
+++ b/paper-spinner-behavior.html
@@ -16,78 +16,66 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.PaperSpinnerBehavior = {
 
     listeners: {
-      'animationend': 'reset',
-      'webkitAnimationEnd': 'reset'
+      'animationend': '__reset',
+      'webkitAnimationEnd': '__reset'
     },
 
     properties: {
       /**
        * Displays the spinner.
-       *
-       * @attribute active
-       * @type boolean
-       * @default false
        */
       active: {
         type: Boolean,
         value: false,
         reflectToAttribute: true,
-        observer: '_activeChanged'
+        observer: '__activeChanged'
       },
 
       /**
        * Alternative text content for accessibility support.
        * If alt is present, it will add an aria-label whose content matches alt when active.
        * If alt is not present, it will default to 'loading' as the alt value.
-       *
-       * @attribute alt
-       * @type string
-       * @default 'loading'
        */
       alt: {
         type: String,
         value: 'loading',
-        observer: '_altChanged'
+        observer: '__altChanged'
       },
 
-      /**
-       * True when the spinner is going from active to inactive. This is represented by a fade
-       * to 0% opacity to the user.
-       */
-      _coolingDown: {
+      __coolingDown: {
         type: Boolean,
         value: false
       },
 
-      _spinnerContainerClassName: {
+      __spinnerContainerClassName: {
         type: String,
-        computed: '_computeSpinnerContainerClassName(active, _coolingDown)'
+        computed: '__computeSpinnerContainerClassName(active, __coolingDown)'
       }
     },
 
-    _computeSpinnerContainerClassName: function(active, coolingDown) {
+    __computeSpinnerContainerClassName: function(active, coolingDown) {
       return [
         active || coolingDown ? 'active' : '',
         coolingDown ? 'cooldown' : ''
       ].join(' ');
     },
 
-    _activeChanged: function(active, old) {
-      this._setAriaHidden(!active);
-      this._coolingDown = !active && old;
+    __activeChanged: function(active, old) {
+      this.__setAriaHidden(!active);
+      this.__coolingDown = !active && old;
     },
 
-    _altChanged: function(alt) {
+    __altChanged: function(alt) {
       // user-provided `aria-label` takes precedence over prototype default
       if (alt === this.getPropertyInfo('alt').value) {
         this.alt = this.getAttribute('aria-label') || alt;
       } else {
-        this._setAriaHidden(alt==='');
+        this.__setAriaHidden(alt==='');
         this.setAttribute('aria-label', alt);
       }
     },
 
-    _setAriaHidden: function(hidden) {
+    __setAriaHidden: function(hidden) {
       var attr = 'aria-hidden';
       if (hidden) {
         this.setAttribute(attr, 'true');
@@ -96,9 +84,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    reset: function() {
+    __reset: function() {
       this.active = false;
-      this._coolingDown = false;
+      this.__coolingDown = false;
     }
   };
 </script>

--- a/paper-spinner-behavior.html
+++ b/paper-spinner-behavior.html
@@ -1,0 +1,104 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+
+  /** @polymerBehavior */
+  Polymer.PaperSpinnerBehavior = {
+
+    listeners: {
+      'animationend': 'reset',
+      'webkitAnimationEnd': 'reset'
+    },
+
+    properties: {
+      /**
+       * Displays the spinner.
+       *
+       * @attribute active
+       * @type boolean
+       * @default false
+       */
+      active: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+        observer: '_activeChanged'
+      },
+
+      /**
+       * Alternative text content for accessibility support.
+       * If alt is present, it will add an aria-label whose content matches alt when active.
+       * If alt is not present, it will default to 'loading' as the alt value.
+       *
+       * @attribute alt
+       * @type string
+       * @default 'loading'
+       */
+      alt: {
+        type: String,
+        value: 'loading',
+        observer: '_altChanged'
+      },
+
+      /**
+       * True when the spinner is going from active to inactive. This is represented by a fade
+       * to 0% opacity to the user.
+       */
+      _coolingDown: {
+        type: Boolean,
+        value: false
+      },
+
+      _spinnerContainerClassName: {
+        type: String,
+        computed: '_computeSpinnerContainerClassName(active, _coolingDown)'
+      }
+    },
+
+    _computeSpinnerContainerClassName: function(active, coolingDown) {
+      return [
+        active || coolingDown ? 'active' : '',
+        coolingDown ? 'cooldown' : ''
+      ].join(' ');
+    },
+
+    _activeChanged: function(active, old) {
+      this._setAriaHidden(!active);
+      this._coolingDown = !active && old;
+    },
+
+    _altChanged: function(alt) {
+      // user-provided `aria-label` takes precedence over prototype default
+      if (alt === this.getPropertyInfo('alt').value) {
+        this.alt = this.getAttribute('aria-label') || alt;
+      } else {
+        this._setAriaHidden(alt==='');
+        this.setAttribute('aria-label', alt);
+      }
+    },
+
+    _setAriaHidden: function(hidden) {
+      var attr = 'aria-hidden';
+      if (hidden) {
+        this.setAttribute(attr, 'true');
+      } else {
+        this.removeAttribute(attr);
+      }
+    },
+
+    reset: function() {
+      this.active = false;
+      this._coolingDown = false;
+    }
+  };
+</script>

--- a/paper-spinner-behavior.html
+++ b/paper-spinner-behavior.html
@@ -45,15 +45,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       __coolingDown: {
         type: Boolean,
         value: false
-      },
-
-      __spinnerContainerClassName: {
-        type: String,
-        computed: '__computeSpinnerContainerClassName(active, __coolingDown)'
       }
     },
 
-    __computeSpinnerContainerClassName: function(active, coolingDown) {
+    __computeContainerClasses: function(active, coolingDown) {
       return [
         active || coolingDown ? 'active' : '',
         coolingDown ? 'cooldown' : ''

--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -50,7 +50,7 @@ Custom property | Description | Default
   <template>
     <style include="paper-spinner-styles"></style>
 
-    <div id="spinnerContainer" class-name="[[__spinnerContainerClassName]]">
+    <div id="spinnerContainer" class-name="[[__computeContainerClasses(active, __coolingDown)]]">
       <div class="spinner-layer">
         <div class="circle-clipper left">
           <div class="circle"></div>

--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -50,7 +50,7 @@ Custom property | Description | Default
   <template>
     <style include="paper-spinner-styles"></style>
 
-    <div id="spinnerContainer" class-name="[[_spinnerContainerClassName]]">
+    <div id="spinnerContainer" class-name="[[__spinnerContainerClassName]]">
       <div class="spinner-layer">
         <div class="circle-clipper left">
           <div class="circle"></div>

--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -17,13 +17,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 Material design: [Progress & activity](https://www.google.com/design/spec/components/progress-activity.html)
 
-Element providing a multiple color material design circular spinner.
+Element providing a single color material design circular spinner.
 
-    <paper-spinner active></paper-spinner>
+    <paper-spinner-lite active></paper-spinner-lite>
 
-The default spinner cycles between four layers of colors; by default they are
-blue, red, yellow and green. It can be customized to cycle between four different
-colors. Use <paper-spinner-lite> for single color spinners.
+The default spinner is blue. It can be customized to be a different color.
 
 ### Accessibility
 
@@ -32,7 +30,7 @@ it defaults to 'loading'.
 Empty alt can be provided to mark the element as decorative if alternative content is provided
 in another form (e.g. a text block following the spinner).
 
-    <paper-spinner alt="Loading contacts list" active></paper-spinner>
+    <paper-spinner-lite alt="Loading contacts list" active></paper-spinner-lite>
 
 ### Styling
 
@@ -40,53 +38,20 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-spinner-layer-1-color` | Color of the first spinner rotation | `--google-blue-500`
-`--paper-spinner-layer-2-color` | Color of the second spinner rotation | `--google-red-500`
-`--paper-spinner-layer-3-color` | Color of the third spinner rotation | `--google-yellow-500`
-`--paper-spinner-layer-4-color` | Color of the fourth spinner rotation | `--google-green-500`
+`--paper-spinner-color` | Color of the spinner | `--google-blue-500`
 
 @group Paper Elements
-@element paper-spinner
+@element paper-spinner-lite
 @hero hero.svg
 @demo demo/index.html
 -->
 
-<dom-module id="paper-spinner">
+<dom-module id="paper-spinner-lite">
   <template>
     <style include="paper-spinner-styles"></style>
 
     <div id="spinnerContainer" class-name="[[_spinnerContainerClassName]]">
-      <div class="spinner-layer layer-1">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
-        </div>
-      </div>
-
-      <div class="spinner-layer layer-2">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
-        </div>
-      </div>
-
-      <div class="spinner-layer layer-3">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
-        </div>
-      </div>
-
-      <div class="spinner-layer layer-4">
+      <div class="spinner-layer">
         <div class="circle-clipper left">
           <div class="circle"></div>
         </div><div class="gap-patch">
@@ -100,7 +65,7 @@ Custom property | Description | Default
 
   <script>
     Polymer({
-      is: 'paper-spinner',
+      is: 'paper-spinner-lite',
 
       behaviors: [
         Polymer.PaperSpinnerBehavior

--- a/paper-spinner-styles.html
+++ b/paper-spinner-styles.html
@@ -67,6 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         height: 100%;
         opacity: 0;
         white-space: nowrap;
+        border-color: var(--paper-spinner-color, --google-blue-500);
       }
 
       .layer-1 {
@@ -98,6 +99,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * specific properties properly, treats them as -webkit-animation, and overrides the
        * other animation rules. See https://github.com/Polymer/platform/issues/53.
        */
+      .active .spinner-layer {
+        /* durations: 4 * ARCTIME */
+        -webkit-animation: fill-unfill-rotate 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
+        animation: fill-unfill-rotate 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
+        opacity: 1;
+      }
+
       .active .spinner-layer.layer-1 {
         /* durations: 4 * ARCTIME */
         -webkit-animation: fill-unfill-rotate 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both, layer-1-fade-in-out 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -55,7 +55,7 @@ Custom property | Description | Default
   <template>
     <style include="paper-spinner-styles"></style>
 
-    <div id="spinnerContainer" class-name="[[__spinnerContainerClassName]]">
+    <div id="spinnerContainer" class-name="[[__computeContainerClasses(active, __coolingDown)]]">
       <div class="spinner-layer layer-1">
         <div class="circle-clipper left">
           <div class="circle"></div>

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -55,7 +55,7 @@ Custom property | Description | Default
   <template>
     <style include="paper-spinner-styles"></style>
 
-    <div id="spinnerContainer" class-name="[[_spinnerContainerClassName]]">
+    <div id="spinnerContainer" class-name="[[__spinnerContainerClassName]]">
       <div class="spinner-layer layer-1">
         <div class="circle-clipper left">
           <div class="circle"></div>


### PR DESCRIPTION
This branch adds a single color `<paper-spinner-lite>` element that uses less DOM elements. This is much cheaper than styling all 4 layers with the same color, and this should improve performance.