### PR TITLE
Fix invalid class name (trailing space)

### DIFF
--- a/paper-spinner-behavior.html
+++ b/paper-spinner-behavior.html
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return [
         active || coolingDown ? 'active' : '',
         coolingDown ? 'cooldown' : ''
-      ].join(' ');
+      ].filter(c => !!c).join(' ');
     },
 
     __activeChanged: function(active, old) {


### PR DESCRIPTION
ShadyCSS shim would throw an error in Firefox and Chrome <54 if the class name was "active ".