### PR TITLE
Spinner pseudo styles changed to div styles

### DIFF
--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -62,7 +62,7 @@ Custom property | Description | Default
     </div>
   </template>
 
-  <script>
+  <script> 
     Polymer({
       is: 'paper-spinner-lite',
 

--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -50,14 +50,14 @@ Custom property | Description | Default
   <template strip-whitespace>
     <style include="paper-spinner-styles"></style>
 
-    <div
-        id="spinnerContainer"
-        class-name="[[__computeContainerClasses(active, __coolingDown)]]"
-        on-animationend="__reset"
-        on-webkit-animation-end="__reset">
+    <div id="spinnerContainer" class-name="[[__computeContainerClasses(active, __coolingDown)]]" on-animationend="__reset" on-webkit-animation-end="__reset">
       <div class="spinner-layer">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
     </div>
   </template>

--- a/paper-spinner-styles.html
+++ b/paper-spinner-styles.html
@@ -235,6 +235,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: hidden;
       }
 
+      .circle-clipper .circle {
+        box-sizing: border-box;
+        border-width: var(--paper-spinner-stroke-width, 3px);
+        border-style: solid;
+        border-bottom-color: transparent !important;
+        border-radius: 50%;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+
       /**
        * Patch the gap that appear between the two adjacent div.circle-clipper while the
        * spinner is rotating (appears on Chrome 50, Safari 9.1.1, and Edge).
@@ -245,8 +258,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-top-style: solid;
       }
 
-      .spinner-layer::after,
-      .circle-clipper::after {
+      .spinner-layer::after {
         content: '';
         box-sizing: border-box;
         position: absolute;
@@ -255,29 +267,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-radius: 50%;
       }
 
-      .circle-clipper::after {
-        bottom: 0;
-        width: 200%;
-        border-style: solid;
-        border-bottom-color: transparent !important;
-      }
+    
 
-      .circle-clipper.left::after {
-        left: 0;
+
+      .circle-clipper.left .circle {
+        right:-100%;
         border-right-color: transparent !important;
-        -webkit-transform: rotate(129deg);
         transform: rotate(129deg);
       }
 
-      .circle-clipper.right::after {
+      .circle-clipper.right .circle {
         left: -100%;
         border-left-color: transparent !important;
-        -webkit-transform: rotate(-129deg);
         transform: rotate(-129deg);
       }
 
       .active .gap-patch::after,
-      .active .circle-clipper::after {
+      .active .circle-clipper .circle {
         -webkit-animation-duration: var(--paper-spinner-expand-contract-duration);
         -webkit-animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
         -webkit-animation-iteration-count: infinite;
@@ -286,12 +292,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         animation-iteration-count: infinite;
       }
 
-      .active .circle-clipper.left::after {
+      .active .circle-clipper.left .circle {
         -webkit-animation-name: left-spin;
         animation-name: left-spin;
       }
 
-      .active .circle-clipper.right::after {
+      .active .circle-clipper.right .circle {
         -webkit-animation-name: right-spin;
         animation-name: right-spin;
       }

--- a/paper-spinner-styles.html
+++ b/paper-spinner-styles.html
@@ -265,7 +265,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         top: 0;
         border-width: var(--paper-spinner-stroke-width, 3px);
         border-radius: 50%;
-      }
+      } 
 
     
 

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="paper-spinner-behavior.html">
-<link rel="import" href="paper-spinner-styles.html">
+<link rel="import" href="paper-spinner-styles.html"> 
 
 <!--
 Material design: [Progress & activity](https://www.google.com/design/spec/components/progress-activity.html)

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -55,29 +55,42 @@ Custom property | Description | Default
   <template strip-whitespace>
     <style include="paper-spinner-styles"></style>
 
-    <div
-        id="spinnerContainer"
-        class-name="[[__computeContainerClasses(active, __coolingDown)]]"
-        on-animationend="__reset"
-        on-webkit-animation-end="__reset">
+    <div id="spinnerContainer" class-name="[[__computeContainerClasses(active, __coolingDown)]]" on-animationend="__reset" on-webkit-animation-end="__reset">
       <div class="spinner-layer layer-1">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-2">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-3">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-4">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Observation for Safari: Inside Shadow DOM, pseudo elements (::after and ::before) do not take animation styles properly. 

Solution: Instead of pseudo elements, inner divs givern styles which can work on safari