### PR TITLE
Replace .circle-clipper::after with .circle to workaround safari bug on 2.x branch

### DIFF
--- a/paper-spinner-lite.html
+++ b/paper-spinner-lite.html
@@ -56,8 +56,12 @@ Custom property | Description | Default
         on-animationend="__reset"
         on-webkit-animation-end="__reset">
       <div class="spinner-layer">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
     </div>
   </template>

--- a/paper-spinner-styles.html
+++ b/paper-spinner-styles.html
@@ -240,14 +240,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * spinner is rotating (appears on Chrome 50, Safari 9.1.1, and Edge).
        */
       .spinner-layer::after {
+        content: '';
         left: 45%;
         width: 10%;
         border-top-style: solid;
       }
 
       .spinner-layer::after,
-      .circle-clipper::after {
-        content: '';
+      .circle-clipper .circle {
         box-sizing: border-box;
         position: absolute;
         top: 0;
@@ -255,21 +255,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-radius: 50%;
       }
 
-      .circle-clipper::after {
+      .circle-clipper .circle {
         bottom: 0;
         width: 200%;
         border-style: solid;
         border-bottom-color: transparent !important;
       }
 
-      .circle-clipper.left::after {
+      .circle-clipper.left .circle {
         left: 0;
         border-right-color: transparent !important;
         -webkit-transform: rotate(129deg);
         transform: rotate(129deg);
       }
 
-      .circle-clipper.right::after {
+      .circle-clipper.right .circle {
         left: -100%;
         border-left-color: transparent !important;
         -webkit-transform: rotate(-129deg);
@@ -277,7 +277,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .active .gap-patch::after,
-      .active .circle-clipper::after {
+      .active .circle-clipper .circle {
         -webkit-animation-duration: var(--paper-spinner-expand-contract-duration);
         -webkit-animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
         -webkit-animation-iteration-count: infinite;
@@ -286,12 +286,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         animation-iteration-count: infinite;
       }
 
-      .active .circle-clipper.left::after {
+      .active .circle-clipper.left .circle {
         -webkit-animation-name: left-spin;
         animation-name: left-spin;
       }
 
-      .active .circle-clipper.right::after {
+      .active .circle-clipper.right .circle {
         -webkit-animation-name: right-spin;
         animation-name: right-spin;
       }

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -61,23 +61,39 @@ Custom property | Description | Default
         on-animationend="__reset"
         on-webkit-animation-end="__reset">
       <div class="spinner-layer layer-1">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-2">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-3">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
 
       <div class="spinner-layer layer-4">
-        <div class="circle-clipper left"></div>
-        <div class="circle-clipper right"></div>
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div>
+        <div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Same changes as #89 but against the 2.x branch